### PR TITLE
feat: Add support for infinite queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ Also, don't forget to install the dependencies before starting the simulation.
 ```bash
 pip install -r requirements.txt
 ```
+
+## Configuration file
+
+When running with the `--help` flag, you'll see that the program also supports generating an initial YAML configuration file with default configs for you to get started. The YAML file is pretty self-explanatory, but a few points to note are:
+
+- Under the `queues` section, if the `capacity` is omitted, then it will default to infinity.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ pip install -r requirements.txt
 When running with the `--help` flag, you'll see that the program also supports generating an initial YAML configuration file with default configs for you to get started. The YAML file is pretty self-explanatory, but a few points to note are:
 
 - Under the `queues` section, if the `capacity` is omitted, then it will default to infinity.
+- Under que `queues` section, if `min_arrival_time` and `max_arrival_time` (arrival interval to the queue) are omitted, then it is assumed that the queue doesn't receive any new clients from the exterior of the system. It can still receive clients forwarded from other queues, though.

--- a/configs/configs.py
+++ b/configs/configs.py
@@ -1,4 +1,4 @@
-from queue import EXTERIOR
+from constants import EXTERIOR, INFINITY
 from pydantic import validate_call
 import os
 import yaml
@@ -49,6 +49,7 @@ DEFAULT_CONFIGS: dict = {
         }
     ]
 }
+
 class ConfigsValidationError(Exception):
     """
     Custom exception for configuration validation errors.
@@ -101,7 +102,6 @@ def load_and_validate_configs(configs_path: str) -> dict:
         if not isinstance(qc, dict): raise ConfigsValidationError(f"'queues[{idx}]': must be a dictionary")
         try:
             qc["servers"]
-            qc["capacity"]
             qc["min_departure_time"]
             qc["max_departure_time"]
         except KeyError as e:
@@ -111,6 +111,7 @@ def load_and_validate_configs(configs_path: str) -> dict:
         # with default values
         if not "min_arrival_time" in qc: qc["min_arrival_time"] = 0.0
         if not "max_arrival_time" in qc: qc["max_arrival_time"] = 0.0
+        if not "capacity"         in qc: qc["capacity"] = INFINITY
         # (further validation on the individual queue fields can be done when instantiating the Queue objects)
     
     if not isinstance(network_configs, list): raise ConfigsValidationError("'network': must be a list")

--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -1,0 +1,1 @@
+from .constants import EXTERIOR, INFINITY

--- a/constants/constants.py
+++ b/constants/constants.py
@@ -1,0 +1,7 @@
+import sys
+
+# Represents the ID of the queue which goes to the out world
+EXTERIOR: int = -1
+
+# Represents a very large integer, used to represent positive integer infinity
+INFINITY: int = sys.maxsize

--- a/queue/__init__.py
+++ b/queue/__init__.py
@@ -1,1 +1,1 @@
-from .queue import Queue, Connection, EXTERIOR
+from .queue import Queue, Connection

--- a/queue/queue.py
+++ b/queue/queue.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List
+from typing import Tuple, List, Dict
 from scheduler import Event, EventType
 from tabulate import tabulate
 from pydantic import validate_call
@@ -6,9 +6,8 @@ from dataclasses import dataclass, field
 import heapq
 import copy
 from rand.linearcongruent import RandomGenerator
-
-# Represents the ID of the queue which goes to the out world
-EXTERIOR: int = -1
+from collections import defaultdict
+from constants import EXTERIOR, INFINITY
 
 @dataclass(order=True)
 class Connection:
@@ -63,7 +62,7 @@ class Queue:
         self.MIN_DEPARTURE_TIME: float             = departure_interval[0]
         self.MAX_DEPARTURE_TIME: float             = departure_interval[1]
         self.current_clients:    int               = 0
-        self.states:             List[float]       = [0.0] * (capacity + 1)
+        self.states:             Dict[int, float]  = defaultdict(float)
         self.losses:             int               = 0
         self.connections:        List[Connection]  = []
         self.rnd:                RandomGenerator   = RandomGenerator()
@@ -92,7 +91,8 @@ class Queue:
             prob  = f"{(self.states[i] / global_time)*100:.2f}%"
             data.append([state, time, prob])
         results  = f"------------------ QUEUE {self.ID} ------------------\n"
-        results += f"Configuration: G/G/{self.SERVERS}/{self.CAPACITY}\n"
+        capacity = f"/{self.CAPACITY}" if self.CAPACITY != INFINITY else ""
+        results += f"Configuration: G/G/{self.SERVERS}{capacity}\n"
         if self.MIN_ARRIVAL_TIME != 0 or self.MAX_ARRIVAL_TIME != 0:
             results += f"Arrivals:   [{self.MIN_ARRIVAL_TIME:6.2f}, {self.MAX_ARRIVAL_TIME:6.2f}]\n"
         results += f"Departures: [{self.MIN_DEPARTURE_TIME:6.2f}, {self.MAX_DEPARTURE_TIME:6.2f}]\n"

--- a/simulator.py
+++ b/simulator.py
@@ -1,4 +1,5 @@
-from queue import Queue, Connection, EXTERIOR
+from queue import Queue, Connection
+from constants import EXTERIOR
 from scheduler import Scheduler, Event, EventType
 from rand.linearcongruent import RandomGenerator
 import argparse

--- a/simulator.py
+++ b/simulator.py
@@ -26,7 +26,7 @@ def default_configs():
         return
 
     with open(DEFAULT_CONFIGS_FILENAME, "w") as f:
-        yaml.dump(DEFAULT_CONFIGS, f)
+        yaml.safe_dump(DEFAULT_CONFIGS, f)
 
     logging.info(f"Default configurations written to the {DEFAULT_CONFIGS_FILENAME} file.")
 


### PR DESCRIPTION
### Description

This PR adds support for infinite queues to the queue simulation system by omitting a queue's capacity.

### Changelog

* Move shared `EXTERIOR` and `INFINITY` constants into a `constants` module to avoid import cycles.
* Default the capacity of a queue to `INFINITY` instead of raising an error when it's not specified.
* Use a `defaultdict` instead of a list to represent each possible state of the queue to easier account for infinite queues without allocating an "infinite" list.
* Omit the capacity _K_ of the queue when printing it, according to Kendall's notation (_A/S/c/K_).